### PR TITLE
Simplify config to accept provider and scorers as top-level keys

### DIFF
--- a/.changeset/dry-eggs-hang.md
+++ b/.changeset/dry-eggs-hang.md
@@ -1,0 +1,6 @@
+---
+"@empiricalrun/cli": minor
+"@empiricalrun/types": patch
+---
+
+feat: simplify config to accept provider, scorers as top-level keys

--- a/docs/models/basics.mdx
+++ b/docs/models/basics.mdx
@@ -20,7 +20,7 @@ The rest of this doc focuses on the `model` type.
 
 To test an LLM, specify the following properties in the configuration:
 
-- `provider`: Name of the inference provider (e.g. `openai`, or other [supported providers](#supported-providers))
+- `provider`: Name of the inference provider (e.g. `openai`, or other [supported providers](#supported-providers)). If models from different providers are being used, the `provider` can be included in the run object
 - `model`: Name of the model (e.g. `gpt-3.5-turbo` or `claude-3-haiku`)
 - `prompt`: Prompt sent to the model, with optional [placeholders](#placeholders)
 - `name` [optional]: A name or label for this run (auto-generated if not specified)
@@ -29,10 +29,10 @@ You can configure as many model providers as you like. These models will be show
 side-by-side comparison view in the web reporter.
 
 ```json empiricalrc.json
+"provider": "openai",
 "runs": [
   {
     "type": "model",
-    "provider": "openai",
     "model": "gpt-3.5-turbo",
     "prompt": "Hey I'm {{user_name}}"
   }
@@ -99,10 +99,10 @@ becomes `stop_sequences` for Anthropic.)
 You can add other parameters or override this behavior with [passthrough](#passthrough).
 
 ```json empiricalrc.json
+"provider": "openai",
 "runs": [
   {
     "type": "model",
-    "provider": "openai",
     "model": "gpt-3.5-turbo",
     "prompt": "Hey I'm {{user_name}}",
     "parameters": {
@@ -120,10 +120,10 @@ parameters will be passed as-is to the model.
 For example, Mistral models support a `safePrompt` parameter for [guardrailing](https://docs.mistral.ai/platform/guardrailing/).
 
 ```json empiricalrc.json
+"provider": "mistral",
 "runs": [
   {
     "type": "model",
-    "provider": "mistral",
     "model": "mistral-tiny",
     "prompt": "Hey I'm {{user_name}}",
     "parameters": {
@@ -139,10 +139,10 @@ For example, Mistral models support a `safePrompt` parameter for [guardrailing](
 You can set the timeout duration in milliseconds under model parameters in the `empiricalrc.json` file. This might be required for prompt completions that are expected to take more time, for example while running models like Claude Opus. If no specific value is assigned, the default timeout duration of 30 seconds will be applied.
 
 ```json empiricalrc.json
+"provider": "anthropic",
 "runs": [
   {
     "type": "model",
-    "provider": "anthropic",
     "model": "claude-3-opus",
     "prompt": "Hey I'm {{user_name}}",
     "parameters": {

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Quick start'
-description: 'Try Empirical in 3 steps'
+title: "Quick start"
+description: "Try Empirical in 3 steps"
 ---
 
 Empirical bundles together a CLI and a web app. The CLI handles running tests and
@@ -32,6 +32,7 @@ Our test will succeed if the model outputs valid JSON.
     ```sh
     cat empiricalrc.json
     ```
+
   </Step>
 
   <Step title="Run the test">
@@ -43,6 +44,7 @@ Our test will succeed if the model outputs valid JSON.
 
     This step requires the `OPENAI_API_KEY` environment variable to authenticate with
     OpenAI. This execution will cost $0.0026, based on the selected models.
+
   </Step>
 
   <Step title="See results">
@@ -52,6 +54,7 @@ Our test will succeed if the model outputs valid JSON.
     ```sh
     npx @empiricalrun/cli ui
     ```
+
   </Step>
 
   <Step title="[Bonus] Fix GPT-4 Turbo">
@@ -75,21 +78,15 @@ Our test will succeed if the model outputs valid JSON.
     <Accordion title="empiricalrc.json: Updated with JSON mode">
     ```json empiricalrc.json
     {
+      "provider": "openai",
       "runs": [
         {
           "type": "model",
-          "provider": "openai",
           "model": "gpt-3.5-turbo",
           "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-          "scorers": [
-            {
-              "type": "is-json"
-            }
-          ]
         },
         {
           "type": "model",
-          "provider": "openai",
           "model": "gpt-4-turbo-preview",
           "parameters": {
             "response_format": {
@@ -97,12 +94,12 @@ Our test will succeed if the model outputs valid JSON.
             }
           },
           "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-          "scorers": [
+        }
+      ],
+      "scorers": [
             {
               "type": "is-json"
             }
-          ]
-        }
       ],
       "dataset": {
         "samples": [
@@ -124,9 +121,9 @@ Our test will succeed if the model outputs valid JSON.
 
     Re-running the test with `npx @empiricalrun/cli run` will give us better results
     for GPT-4 Turbo.
+
   </Step>
 </Steps>
-
 
 ## Make it yours
 

--- a/docs/scoring/basics.mdx
+++ b/docs/scoring/basics.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Basics'
-description: 'Automated evaluation of output quality with scorers'
+title: "Basics"
+description: "Automated evaluation of output quality with scorers"
 ---
 
 Scorers are functions that rate model outputs between 0 and 1. These scores
@@ -10,18 +10,24 @@ Choose the right scoring functions for your use-case by defining the
 `scorers` field in your configuration files. You can define as many scorers
 as you like.
 
+If different runs require different set of scorers, the `scorers` array can be set in each run object instead.
+
 ```json empiricalrc.json
 {
-    "type": "model",
-    "name": "gpt-3.5-turbo run",
+    ...
     "provider": "openai",
-    "model": "gpt-3.5-turbo",
-    "prompt": "Always respond with a JSON object.",
+    {
+        "type": "model",
+        "name": "gpt-3.5-turbo run",
+        "model": "gpt-3.5-turbo",
+        "prompt": "Always respond with a JSON object.",
+    },
     "scorers": [
-        {
-            "type": "is-json"
-        }
-    ]
+            {
+                "type": "is-json"
+            }
+        ],
+    ...
 }
 ```
 

--- a/examples/basic/empiricalrc.json
+++ b/examples/basic/empiricalrc.json
@@ -1,32 +1,26 @@
 {
   "$schema": "https://assets.empirical.run/config/schema/latest.json",
+  "provider": "openai",
   "runs": [
     {
       "type": "model",
-      "provider": "openai",
       "model": "gpt-3.5-turbo",
-      "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-      "scorers": [
-        {
-          "type": "is-json"
-        }
-      ]
+      "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}"
     },
     {
       "type": "model",
-      "provider": "openai",
       "model": "gpt-4-turbo-preview",
       "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
       "parameters": {
         "response_format": {
           "type": "json_object"
         }
-      },
-      "scorers": [
-        {
-          "type": "is-json"
-        }
-      ]
+      }
+    }
+  ],
+  "scorers": [
+    {
+      "type": "is-json"
     }
   ],
   "dataset": {

--- a/examples/chatbot/empiricalrc.json
+++ b/examples/chatbot/empiricalrc.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://assets.empirical.run/config/schema/latest.json",
+  "provider": "openai",
   "runs": [
     {
       "name": "less context setting",
       "type": "model",
-      "provider": "openai",
       "model": "gpt-3.5-turbo",
       "prompt": "{{user_message}}",
       "scorers": [
@@ -19,7 +19,6 @@
       "name": "adequate context setting",
       "type": "model",
       "model": "gpt-3.5-turbo",
-      "provider": "openai",
       "prompt": "You are Sarah, a political scientist. Respond to the user with your best answer. Make sure to respond to them with their name.\n\n{{user_name}}: {{user_message}}",
       "scorers": [
         {

--- a/examples/humaneval/empiricalrc.json
+++ b/examples/humaneval/empiricalrc.json
@@ -1,21 +1,21 @@
 {
   "$schema": "https://assets.empirical.run/config/schema/latest.json",
+  "provider": "openai",
   "runs": [
     {
       "type": "model",
-      "provider": "openai",
       "model": "gpt-3.5-turbo",
       "prompt": "Complete the following python function. Return only the completed function so that it can be directly run on a Python shell, including imports like from typing import List.\n```python\n{{prompt}}\n```",
       "parameters": {
         "temperature": 0.1
-      },
-      "scorers": [
-        {
-          "type": "py-script",
-          "path": "score.py",
-          "name": "unit-tests"
-        }
-      ]
+      }
+    }
+  ],
+  "scorers": [
+    {
+      "type": "py-script",
+      "path": "score.py",
+      "name": "unit-tests"
     }
   ],
   "dataset": {

--- a/examples/spider/empiricalrc.json
+++ b/examples/spider/empiricalrc.json
@@ -35,16 +35,16 @@
       "type": "model",
       "provider": "google",
       "model": "gemini-1.0-pro",
-      "prompt": "You are an SQLite expert who can convert natural language questions to SQL queries for the database schema given below.\n\nDatabase schema:\n{{schema}}\n\nAnswer the following question with only the SQL query.\n\nQuestion: {{question}}",
-      "scorers": [
-        {
-          "type": "sql-syntax"
-        },
-        {
-          "type": "py-script",
-          "path": "execution_accuracy.py"
-        }
-      ]
+      "prompt": "You are an SQLite expert who can convert natural language questions to SQL queries for the database schema given below.\n\nDatabase schema:\n{{schema}}\n\nAnswer the following question with only the SQL query.\n\nQuestion: {{question}}"
+    }
+  ],
+  "scorers": [
+    {
+      "type": "sql-syntax"
+    },
+    {
+      "type": "py-script",
+      "path": "execution_accuracy.py"
     }
   ],
   "dataset": {

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -102,7 +102,22 @@ program
 
     console.log(buildSuccessLog(`read ${configFileName} file successfully`));
     const jsonStr = data.toString();
-    const { runs, dataset: datasetConfig } = JSON.parse(jsonStr) as RunsConfig;
+    const {
+      runs,
+      dataset: datasetConfig,
+      provider,
+      scorers,
+    } = JSON.parse(jsonStr) as RunsConfig;
+    runs.forEach((run) => {
+      if (run.type === "model") {
+        if (provider && !run.provider) {
+          run["provider"] = provider;
+        }
+      }
+      if (!run.scorers && scorers) {
+        run["scorers"] = scorers;
+      }
+    });
     // TODO: add check here for empty runs config. Add validator of the file
     let dataset: Dataset;
     const store = new EmpiricalStore();

--- a/packages/cli/src/runs/config/defaults/index.ts
+++ b/packages/cli/src/runs/config/defaults/index.ts
@@ -2,30 +2,24 @@ import { RunsConfig } from "../../../types";
 
 export const config: RunsConfig = {
   $schema: "https://assets.empirical.run/config/schema/latest.json",
+  provider: "openai",
   runs: [
     {
       type: "model",
-      provider: "openai",
       model: "gpt-3.5-turbo",
       prompt:
         "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-      scorers: [
-        {
-          type: "is-json",
-        },
-      ],
     },
     {
       type: "model",
-      provider: "openai",
       model: "gpt-4-turbo-preview",
       prompt:
         "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-      scorers: [
-        {
-          type: "is-json",
-        },
-      ],
+    },
+  ],
+  scorers: [
+    {
+      type: "is-json",
     },
   ],
   dataset: {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,7 +1,9 @@
-import { RunConfig, DatasetConfig } from "@empiricalrun/types";
+import { RunConfig, DatasetConfig, Scorer } from "@empiricalrun/types";
 
 export type RunsConfig = {
   runs: RunConfig[];
   dataset: DatasetConfig;
   $schema?: string;
+  provider?: "openai" | "mistral" | "anthropic" | "google" | "fireworks";
+  scorers?: Scorer[];
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -77,7 +77,8 @@ interface ModelParameters {
 
 export interface ModelRunConfig extends RunConfigBase {
   type: "model";
-  provider: "openai" | "mistral" | "google" | "anthropic" | "fireworks";
+  provider?: "openai" | "mistral" | "google" | "anthropic" | "fireworks";
+  scorers?: Scorer[];
   model: string;
   prompt?: Prompt;
   parameters?: ModelParameters;


### PR DESCRIPTION
- Moved the `provider` and `scorers` configuration to the top-level of the `empiricalrc.json` file, making it easier to manage and apply these settings across multiple runs.
- This change allows users to define the provider and scorers once at the top-level, instead of having to repeat them for each individual run.
- The PR also updates the documentation examples to reflect this new structure, making the configuration more intuitive and easier to understand.

## Files

### .changeset/dry-eggs-hang.md
**Title:** Changelog entry for the config changes

**Changes Summary:**
- Added a changelog entry to document the minor change to the `@empiricalrun/cli` package and the patch change to the `@empiricalrun/types` package.

**Label:** documentation

### docs/models/basics.mdx
**Title:** Update documentation for model configuration

**Changes Summary:**
- Moved the `provider` configuration to the top-level of the `empiricalrc.json` example, instead of including it in each individual run.
- Updated the documentation to reflect this change and explain how the provider can be set for multiple runs.

**Label:** documentation

### docs/quickstart.mdx
**Title:** Update quickstart example with new config structure

**Changes Summary:**
- Moved the `provider` configuration to the top-level of the `empiricalrc.json` example.
- Moved the `scorers` configuration to the top-level, instead of including it in each individual run.

**Label:** documentation

### docs/scoring/basics.mdx
**Title:** Update scoring documentation with new config structure

**Changes Summary:**
- Explained that the `scorers` array can be set at the top-level or within each individual run, depending on the use case.

**Label:** documentation

### examples/*/empiricalrc.json
**Title:** Update example configurations with new structure

**Changes Summary:**
- Moved the `provider` configuration to the top-level of the `empiricalrc.json` examples.
- Moved the `scorers` configuration to the top-level, instead of including it in each individual run.

**Label:** documentation

### packages/cli/src/bin/index.ts
**Title:** Automatically apply provider and scorers to runs

**Changes Summary:**
- Added logic to automatically apply the top-level `provider` and `scorers` configurations to each individual run, if they are not already specified.
- This ensures that the new top-level configuration structure works seamlessly with the existing CLI behavior.

**Label:** enhancement

