### PR TITLE
Centralize 'provider' and 'scorers' in config, streamline JSON structure

### DIFF
--- a/.changeset/dry-eggs-hang.md
+++ b/.changeset/dry-eggs-hang.md
@@ -1,0 +1,6 @@
+---
+"@empiricalrun/cli": minor
+"@empiricalrun/types": patch
+---
+
+feat: simplify config to accept provider, scorers as top-level keys

--- a/docs/models/basics.mdx
+++ b/docs/models/basics.mdx
@@ -20,7 +20,7 @@ The rest of this doc focuses on the `model` type.
 
 To test an LLM, specify the following properties in the configuration:
 
-- `provider`: Name of the inference provider (e.g. `openai`, or other [supported providers](#supported-providers))
+- `provider`: Name of the inference provider (e.g. `openai`, or other [supported providers](#supported-providers)). If models from different providers are being used, the `provider` can be included in the run object
 - `model`: Name of the model (e.g. `gpt-3.5-turbo` or `claude-3-haiku`)
 - `prompt`: Prompt sent to the model, with optional [placeholders](#placeholders)
 - `name` [optional]: A name or label for this run (auto-generated if not specified)
@@ -29,10 +29,10 @@ You can configure as many model providers as you like. These models will be show
 side-by-side comparison view in the web reporter.
 
 ```json empiricalrc.json
+"provider": "openai",
 "runs": [
   {
     "type": "model",
-    "provider": "openai",
     "model": "gpt-3.5-turbo",
     "prompt": "Hey I'm {{user_name}}"
   }
@@ -99,10 +99,10 @@ becomes `stop_sequences` for Anthropic.)
 You can add other parameters or override this behavior with [passthrough](#passthrough).
 
 ```json empiricalrc.json
+"provider": "openai",
 "runs": [
   {
     "type": "model",
-    "provider": "openai",
     "model": "gpt-3.5-turbo",
     "prompt": "Hey I'm {{user_name}}",
     "parameters": {
@@ -120,10 +120,10 @@ parameters will be passed as-is to the model.
 For example, Mistral models support a `safePrompt` parameter for [guardrailing](https://docs.mistral.ai/platform/guardrailing/).
 
 ```json empiricalrc.json
+"provider": "mistral",
 "runs": [
   {
     "type": "model",
-    "provider": "mistral",
     "model": "mistral-tiny",
     "prompt": "Hey I'm {{user_name}}",
     "parameters": {
@@ -139,10 +139,10 @@ For example, Mistral models support a `safePrompt` parameter for [guardrailing](
 You can set the timeout duration in milliseconds under model parameters in the `empiricalrc.json` file. This might be required for prompt completions that are expected to take more time, for example while running models like Claude Opus. If no specific value is assigned, the default timeout duration of 30 seconds will be applied.
 
 ```json empiricalrc.json
+"provider": "anthropic",
 "runs": [
   {
     "type": "model",
-    "provider": "anthropic",
     "model": "claude-3-opus",
     "prompt": "Hey I'm {{user_name}}",
     "parameters": {

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Quick start'
-description: 'Try Empirical in 3 steps'
+title: "Quick start"
+description: "Try Empirical in 3 steps"
 ---
 
 Empirical bundles together a CLI and a web app. The CLI handles running tests and
@@ -32,6 +32,7 @@ Our test will succeed if the model outputs valid JSON.
     ```sh
     cat empiricalrc.json
     ```
+
   </Step>
 
   <Step title="Run the test">
@@ -43,6 +44,7 @@ Our test will succeed if the model outputs valid JSON.
 
     This step requires the `OPENAI_API_KEY` environment variable to authenticate with
     OpenAI. This execution will cost $0.0026, based on the selected models.
+
   </Step>
 
   <Step title="See results">
@@ -52,6 +54,7 @@ Our test will succeed if the model outputs valid JSON.
     ```sh
     npx @empiricalrun/cli ui
     ```
+
   </Step>
 
   <Step title="[Bonus] Fix GPT-4 Turbo">
@@ -75,21 +78,15 @@ Our test will succeed if the model outputs valid JSON.
     <Accordion title="empiricalrc.json: Updated with JSON mode">
     ```json empiricalrc.json
     {
+      "provider": "openai",
       "runs": [
         {
           "type": "model",
-          "provider": "openai",
           "model": "gpt-3.5-turbo",
           "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-          "scorers": [
-            {
-              "type": "is-json"
-            }
-          ]
         },
         {
           "type": "model",
-          "provider": "openai",
           "model": "gpt-4-turbo-preview",
           "parameters": {
             "response_format": {
@@ -97,12 +94,12 @@ Our test will succeed if the model outputs valid JSON.
             }
           },
           "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-          "scorers": [
+        }
+      ],
+      "scorers": [
             {
               "type": "is-json"
             }
-          ]
-        }
       ],
       "dataset": {
         "samples": [
@@ -124,9 +121,9 @@ Our test will succeed if the model outputs valid JSON.
 
     Re-running the test with `npx @empiricalrun/cli run` will give us better results
     for GPT-4 Turbo.
+
   </Step>
 </Steps>
-
 
 ## Make it yours
 

--- a/docs/scoring/basics.mdx
+++ b/docs/scoring/basics.mdx
@@ -1,6 +1,6 @@
 ---
-title: 'Basics'
-description: 'Automated evaluation of output quality with scorers'
+title: "Basics"
+description: "Automated evaluation of output quality with scorers"
 ---
 
 Scorers are functions that rate model outputs between 0 and 1. These scores
@@ -10,18 +10,24 @@ Choose the right scoring functions for your use-case by defining the
 `scorers` field in your configuration files. You can define as many scorers
 as you like.
 
+If different runs require different set of scorers, the `scorers` array can be set in each run object instead.
+
 ```json empiricalrc.json
 {
-    "type": "model",
-    "name": "gpt-3.5-turbo run",
+    ...
     "provider": "openai",
-    "model": "gpt-3.5-turbo",
-    "prompt": "Always respond with a JSON object.",
+    {
+        "type": "model",
+        "name": "gpt-3.5-turbo run",
+        "model": "gpt-3.5-turbo",
+        "prompt": "Always respond with a JSON object.",
+    },
     "scorers": [
-        {
-            "type": "is-json"
-        }
-    ]
+            {
+                "type": "is-json"
+            }
+        ],
+    ...
 }
 ```
 

--- a/examples/basic/empiricalrc.json
+++ b/examples/basic/empiricalrc.json
@@ -1,32 +1,26 @@
 {
   "$schema": "https://assets.empirical.run/config/schema/latest.json",
+  "provider": "openai",
   "runs": [
     {
       "type": "model",
-      "provider": "openai",
       "model": "gpt-3.5-turbo",
-      "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-      "scorers": [
-        {
-          "type": "is-json"
-        }
-      ]
+      "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}"
     },
     {
       "type": "model",
-      "provider": "openai",
       "model": "gpt-4-turbo-preview",
       "prompt": "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
       "parameters": {
         "response_format": {
           "type": "json_object"
         }
-      },
-      "scorers": [
-        {
-          "type": "is-json"
-        }
-      ]
+      }
+    }
+  ],
+  "scorers": [
+    {
+      "type": "is-json"
     }
   ],
   "dataset": {

--- a/examples/chatbot/empiricalrc.json
+++ b/examples/chatbot/empiricalrc.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://assets.empirical.run/config/schema/latest.json",
+  "provider": "openai",
   "runs": [
     {
       "name": "less context setting",
       "type": "model",
-      "provider": "openai",
       "model": "gpt-3.5-turbo",
       "prompt": "{{user_message}}",
       "scorers": [
@@ -19,7 +19,6 @@
       "name": "adequate context setting",
       "type": "model",
       "model": "gpt-3.5-turbo",
-      "provider": "openai",
       "prompt": "You are Sarah, a political scientist. Respond to the user with your best answer. Make sure to respond to them with their name.\n\n{{user_name}}: {{user_message}}",
       "scorers": [
         {

--- a/examples/humaneval/empiricalrc.json
+++ b/examples/humaneval/empiricalrc.json
@@ -1,21 +1,21 @@
 {
   "$schema": "https://assets.empirical.run/config/schema/latest.json",
+  "provider": "openai",
   "runs": [
     {
       "type": "model",
-      "provider": "openai",
       "model": "gpt-3.5-turbo",
       "prompt": "Complete the following python function. Return only the completed function so that it can be directly run on a Python shell, including imports like from typing import List.\n```python\n{{prompt}}\n```",
       "parameters": {
         "temperature": 0.1
-      },
-      "scorers": [
-        {
-          "type": "py-script",
-          "path": "score.py",
-          "name": "unit-tests"
-        }
-      ]
+      }
+    }
+  ],
+  "scorers": [
+    {
+      "type": "py-script",
+      "path": "score.py",
+      "name": "unit-tests"
     }
   ],
   "dataset": {

--- a/examples/spider/empiricalrc.json
+++ b/examples/spider/empiricalrc.json
@@ -35,16 +35,16 @@
       "type": "model",
       "provider": "google",
       "model": "gemini-1.0-pro",
-      "prompt": "You are an SQLite expert who can convert natural language questions to SQL queries for the database schema given below.\n\nDatabase schema:\n{{schema}}\n\nAnswer the following question with only the SQL query.\n\nQuestion: {{question}}",
-      "scorers": [
-        {
-          "type": "sql-syntax"
-        },
-        {
-          "type": "py-script",
-          "path": "execution_accuracy.py"
-        }
-      ]
+      "prompt": "You are an SQLite expert who can convert natural language questions to SQL queries for the database schema given below.\n\nDatabase schema:\n{{schema}}\n\nAnswer the following question with only the SQL query.\n\nQuestion: {{question}}"
+    }
+  ],
+  "scorers": [
+    {
+      "type": "sql-syntax"
+    },
+    {
+      "type": "py-script",
+      "path": "execution_accuracy.py"
     }
   ],
   "dataset": {

--- a/packages/cli/src/bin/index.ts
+++ b/packages/cli/src/bin/index.ts
@@ -102,7 +102,22 @@ program
 
     console.log(buildSuccessLog(`read ${configFileName} file successfully`));
     const jsonStr = data.toString();
-    const { runs, dataset: datasetConfig } = JSON.parse(jsonStr) as RunsConfig;
+    const {
+      runs,
+      dataset: datasetConfig,
+      provider,
+      scorers,
+    } = JSON.parse(jsonStr) as RunsConfig;
+    runs.forEach((run) => {
+      if (run.type === "model") {
+        if (provider && !run.provider) {
+          run["provider"] = provider;
+        }
+      }
+      if (!run.scorers && scorers) {
+        run["scorers"] = scorers;
+      }
+    });
     // TODO: add check here for empty runs config. Add validator of the file
     let dataset: Dataset;
     const store = new EmpiricalStore();

--- a/packages/cli/src/runs/config/defaults/index.ts
+++ b/packages/cli/src/runs/config/defaults/index.ts
@@ -2,30 +2,24 @@ import { RunsConfig } from "../../../types";
 
 export const config: RunsConfig = {
   $schema: "https://assets.empirical.run/config/schema/latest.json",
+  provider: "openai",
   runs: [
     {
       type: "model",
-      provider: "openai",
       model: "gpt-3.5-turbo",
       prompt:
         "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-      scorers: [
-        {
-          type: "is-json",
-        },
-      ],
     },
     {
       type: "model",
-      provider: "openai",
       model: "gpt-4-turbo-preview",
       prompt:
         "Extract the name, age and location from the message, and respond with a JSON object. If an entity is missing, respond with null.\n\nMessage: {{user_message}}",
-      scorers: [
-        {
-          type: "is-json",
-        },
-      ],
+    },
+  ],
+  scorers: [
+    {
+      type: "is-json",
     },
   ],
   dataset: {

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -1,7 +1,9 @@
-import { RunConfig, DatasetConfig } from "@empiricalrun/types";
+import { RunConfig, DatasetConfig, Scorer } from "@empiricalrun/types";
 
 export type RunsConfig = {
   runs: RunConfig[];
   dataset: DatasetConfig;
   $schema?: string;
+  provider?: "openai" | "mistral" | "anthropic" | "google" | "fireworks";
+  scorers?: Scorer[];
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -77,7 +77,8 @@ interface ModelParameters {
 
 export interface ModelRunConfig extends RunConfigBase {
   type: "model";
-  provider: "openai" | "mistral" | "google" | "anthropic" | "fireworks";
+  provider?: "openai" | "mistral" | "google" | "anthropic" | "fireworks";
+  scorers?: Scorer[];
   model: string;
   prompt?: Prompt;
   parameters?: ModelParameters;

--- a/tests/test_packages_cli_src_bin_index.ts.ts
+++ b/tests/test_packages_cli_src_bin_index.ts.ts
@@ -1,0 +1,74 @@
+describe('handleRunCommand', () => {
+  it('should load the configuration file and parse the runs, dataset, provider, and scorers correctly', async () => {
+    const mockData = `{
+      "runs": [
+        {
+          "type": "model",
+          "model": "gpt-3.5-turbo",
+          "prompt": "..."
+        }
+      ],
+      "dataset": {
+        "path": "..."
+      },
+      "provider": "openai",
+      "scorers": [
+        {
+          "type": "is-json"
+        }
+      ]
+    }`;
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(mockData);
+
+    await handleRunCommand(configFileName);
+
+    expect(runs).toEqual([
+      {
+        type: 'model',
+        provider: 'openai',
+        model: 'gpt-3.5-turbo',
+        prompt: '...'
+      }
+    ]);
+    expect(datasetConfig).toEqual({ path: '...' });
+    expect(provider).toBe('openai');
+    expect(scorers).toEqual([
+      {
+        type: 'is-json'
+      }
+    ]);
+  });
+
+  it('should use the provider and scorers from the config if they are not defined in the run', async () => {
+    const mockData = `{
+      "runs": [
+        {
+          "type": "model",
+          "model": "gpt-3.5-turbo",
+          "prompt": "..."
+        }
+      ],
+      "provider": "openai",
+      "scorers": [
+        {
+          "type": "is-json"
+        }
+      ]
+    }`;
+    jest.spyOn(fs, 'readFileSync').mockReturnValue(mockData);
+
+    await handleRunCommand(configFileName);
+
+    expect(runs[0]).toEqual({
+      type: 'model',
+      provider: 'openai',
+      model: 'gpt-3.5-turbo',
+      prompt: '...',
+      scorers: [
+        {
+          type: 'is-json'
+        }
+      ]
+    });
+  });
+});

--- a/tests/test_packages_cli_src_runs_config_defaults_index.ts.ts
+++ b/tests/test_packages_cli_src_runs_config_defaults_index.ts.ts
@@ -1,0 +1,28 @@
+describe('default config', () => {
+  it('should have the expected structure', () => {
+    expect(config).toEqual({
+      $schema: 'https://assets.empirical.run/config/schema/latest.json',
+      provider: 'openai',
+      runs: [
+        {
+          type: 'model',
+          model: 'gpt-3.5-turbo',
+          prompt: expect.any(String)
+        },
+        {
+          type: 'model',
+          model: 'gpt-4-turbo-preview',
+          prompt: expect.any(String)
+        }
+      ],
+      scorers: [
+        {
+          type: 'is-json'
+        }
+      ],
+      dataset: {
+        samples: expect.any(Array)
+      }
+    });
+  });
+});

--- a/tests/test_packages_types_src_index.ts.ts
+++ b/tests/test_packages_types_src_index.ts.ts
@@ -1,0 +1,27 @@
+describe('RunsConfig', () => {
+  it('should have the expected properties', () => {
+    const config: RunsConfig = {
+      runs: [
+        {
+          type: 'model',
+          model: 'gpt-3.5-turbo',
+          prompt: '...'
+        }
+      ],
+      dataset: {
+        path: '...'
+      },
+      provider: 'openai',
+      scorers: [
+        {
+          type: 'is-json'
+        }
+      ]
+    };
+
+    expect(config).toHaveProperty('runs');
+    expect(config).toHaveProperty('dataset');
+    expect(config).toHaveProperty('provider');
+    expect(config).toHaveProperty('scorers');
+  });
+});


### PR DESCRIPTION
## Purpose
This PR simplifies the configuration structure by centralizing the 'provider' and 'scorers' fields in the top-level of the `empiricalrc.json` file. This allows for a more concise and consistent configuration, where the provider and scorers can be defined once and applied to all the runs.

## Critical Changes
- Moved the 'provider' field to the top-level of the `empiricalrc.json` file, allowing it to be shared across all runs. This avoids the need to specify the provider for each individual run.
- Moved the 'scorers' field to the top-level of the `empiricalrc.json` file, allowing the scorers to be defined once and applied to all the runs. Individual runs can still override the scorers if needed.
- Streamlined the JSON structure by removing unnecessary nesting and duplication of the 'provider' and 'scorers' fields in each run.



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' in config, streamline JSON structure

**Original Description:**
## Purpose
This PR simplifies the configuration structure by centralizing the 'provider' and 'scorers' fields in the top-level of the `empiricalrc.json` file. This allows for a more concise and consistent configuration, where the provider and scorers can be defined once and applied to all the runs.

## Critical Changes
- Moved the 'provider' field to the top-level of the `empiricalrc.json` file, allowing it to be shared across all runs. This avoids the need to specify the provider for each individual run.
- Moved the 'scorers' field to the top-level of the `empiricalrc.json` file, allowing the scorers to be defined once and applied to all the runs. Individual runs can still override the scorers if needed.
- Streamlined the JSON structure by removing unnecessary nesting and duplication of the 'provider' and 'scorers' fields in each run.



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' in config, streamline JSON structure

**Original Description:**
## Purpose
This PR simplifies the JSON configuration by making 'provider' and 'scorers' top-level keys, which helps in reducing redundancy across multiple entries. This change aims to streamline the configuration process and ensure consistency across various configuration files.

## Critical Changes
- `packages/cli/src/bin/index.ts`: Updated the parsing logic in `handleRunCommand` to initialize 'provider' and 'scorers' at the top level if not specified in individual runs. This helps in ensuring that a default provider and scorers are applied to all runs unless explicitly overridden.
  ```ts
  if (provider && !run.provider) {
      run["provider"] = provider;
  }
  if (!run.scorers && scorers) {
      run["scorers"] = scorers;
  }
  ```

- `docs/models/basics.mdx and docs/quickstart.mdx`: Documentation has been updated to reflect the structural changes in `.json` files regarding centralized 'provider' and 'scorers'. This includes instructional changes demonstrating how to define these parameters at the top level.

- JSON Configuration Files (`examples/*/*.json`): These files have seen a format overhaul where the 'provider' key is moved up to the top level of `empiricalrc.json`, and a similar adjustment has been made for 'scorers'. Such structural changes enhance the clarity and maintainability of the configuration files.

Additionally, all other changes across various JSON and documentation files consistently reflect this new structure, reducing the need to duplicate 'provider' and 'scorers' definitions across 'run' entries.



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' settings in JSON configuration

**Original Description:**
## Purpose
The changes in this PR aim to centralize the configurations for 'provider' and 'scorers' by moving them to top-level keys in the JSON configuration files. This modification simplifies the configuration structure across various documents and ensures consistent application of these settings in all model runs, enhancing maintainability and readability.

## Critical Changes
- **.changeset/dry-eggs-hang.md**
  Updates the version of `@empiricalrun/cli` to `minor` and `@empiricalrun/types` to `patch`. Introduces a feature to simplify config by accepting `provider` and `scorers` as top-level keys in the configuration.

- **JSON Configuration (multiple files, e.g., `examples/basic/empiricalrc.json`)**
  Removes `provider` and `scorers` fields from individual `runs` objects and includes them as top-level keys in JSON config files. This ensures that all runs inherit these settings uniformly unless specifically overridden, thereby reducing repetition and potential inconsistencies.

- **Documentation Updates (e.g., `docs/models/basics.mdx`, `docs/quickstart.mdx`)**
  All example configurations and documentation materials have been updated to reflect the new centralized configuration approach, helping users adapt to the updated structure. The documentation now includes instructions on how to use top-level `provider` and `scorers`.

- **CLI and Config Handling (`packages/cli/src/bin/index.ts`, `packages/cli/src/runs/config/defaults/index.ts`)**
  Code modification to parse the new top-level `provider` and `scorers`, with logic to fall back to these entries if they are missing in individual `runs` in the JSON configuration. Includes necessary adjustments for handling and merging configurations appropriately.

- **Type Definitions (`packages/types/src/index.ts`)**
  Adjusts the type definitions to make `provider` and `scorers` optional in `ModelRunConfig`. Reflects the changes where `provider` can be either undefined or inherited from the top-level configuration, aligning the codebase with the new config strategy.



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' in JSON configuration

**Original Description:**
## Purpose
This PR aims to simplify the configuration process in Empirical by introducing 'provider' and 'scorers' as top-level elements in JSON. This restructuring helps centralize model provider details and scoring logic, reducing redundancy and potential for errors across various configuration files.

## Critical Changes
{
- In `packages/cli/src/bin/index.ts`, logic has been added to handle missing 'provider' or 'scorers' in model runs by setting them from the new top-level configuration entries. The changes primarily include using the top-level 'provider' and 'scorers' to fill in missing fields in individual model configurations:
  ```typescript
  runs.forEach((run) => {
    if (run.type === "model") {
      if (provider && !run.provider) {
        run["provider"] = provider;
      }
    }
    if (!run.scorers && scorers) {
      run["scorers"] = scorers;
    }
  });
  ```

- The documentation files (`docs/models/basics.mdx`, `docs/quickstart.mdx`, etc.) and example JSON configuration files (e.g., `examples/basic/empiricalrc.json`, `examples/chatbot/empiricalrc.json`) have been modified to showcase and reflect the centralized configuration methodology. Model runs within these configurations are now simplified by removing repetitive declarations of 'provider' and 'scorers' directly associated with individual model runs when these values are defined at the top-level configuration.

- A new utility test suite in `tests/test_packages_cli_src_bin_index.ts.ts` ensures functionality for importing configurations. It verifies that top-level 'provider' and 'scorers' are adequately applied to individual runs when not explicitly defined:
  ```typescript
  it('should use the provider and scorers from the config if they are not defined in the run', async () => {
    // Simulated function and expectations are tested here
  });
  ```
}



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' in JSON configuration

**Original Description:**
## Purpose
This PR streamlines the configuration of models by moving 'provider' and 'scorers' to top-level keys in JSON files, reducing redundancy and improving clarity in specifying model details across various configuration files.

## Critical Changes
- `packages/cli/src/bin/index.ts`: Enhanced the run configuration parser to globally set the 'provider' and 'scorers' if not specified at the individual model level. Changes ensure that all 'model' type runs inherit these settings unless specifically overridden. The relevant code modification:
  ```typescript
  runs.forEach((run) => {
    if(run.type === "model") {
      if(provider && !run.provider) {
        run["provider"] = provider;
      }
    }
    if(!run.scorers && scorers) {
      run["scorers"] = scorers;
    }
  });
  ```

- `packages/cli/src/runs/config/defaults/index.ts` and multiple JSON configuration files (like `examples/basic/empiricalrc.json`, `examples/chatbot/empiricalrc.json`, etc.): 'provider' and 'scorers' fields are extracted and declared at the top level instead of within each model run configuration. This centralizes configuration settings, making the configurations easier to manage and modify.

- Documentation updates in files like `docs/models/basics.mdx` and `docs/scoring/basics.mdx` explaining the new configuration approach, ensuring that users are well-informed on how to use the updated settings.

- Implementation of unit tests in `tests/test_packages_cli_src_bin_index.ts.ts` to validate that 'provider' and 'scorers' are effectively parsed and applied to all model runs if not specifically provided at the run level.



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' in JSON configuration

**Original Description:**
## Purpose
This PR simplifies the configuration by allowing the 'provider' and 'scorers' to be defined at the root of the JSON configuration. This aims to reduce redundancy and streamline the setup process for running models across various documents and examples within the Empirical framework.

## Critical Changes
- **`.changeset/dry-eggs-hang.md`**:
  Updated package versions for `@empiricalrun/cli` to minor and `@empiricalrun/types` to patch, which indicates backwards-compatible enhancements and bug fixes, respectively. The change log introduces the feature of accepting 'provider' and 'scorers' at the top-level.

- **`docs/models/basics.mdx`, `docs/quickstart.mdx`, `examples/basic/empiricalrc.json`**:
  Documentation and examples are updated to reflect the centralization of 'provider' and 'scorers'. Removed individual 'provider' and 'scorers' entries from model runs and added them at the top level of the JSON configuration files. This change is propagated through multiple examples and docs to maintain consistency across usage.

- **`packages/cli/src/bin/index.ts`**:
  Code changes to load and merge 'provider' and 'scorers' from the top level into each model run if they are not explicitly specified in the run. The logic ensures backward compatibility and default behavior, crucial for avoiding breaking changes in existing configurations.

- **Unit Tests Updates**:
  Several unit tests added (`tests/test_packages_cli_src_bin_index.ts.ts`, `tests/test_packages_cli_src_runs_config_defaults_index.ts.ts`) to validate the new configuration handling, ensuring that the implementations work as expected with the centralized settings.

- **TODO comment**:
  A TODO in `packages/cli/src/bin/index.ts` highlights the need to add a validator for empty runs in configurations. This is a potential area for improvement in future updates.



===== Original PR title and description ============

**Original Title:** Centralize 'provider' and 'scorers' in Empirical configuration

**Original Description:**
## Purpose
This PR modifies how 'provider' and 'scorers' are specified in configuration files, enabling them to be defined at a higher level once per config rather than repeatedly in individual runs. This reduces redundancy and potential errors in config files.

## Critical Changes
{
- File `.changeset/dry-eggs-hang.md` introduces a minor update to `@empiricalrun/cli` and a patch for `@empiricalrun/types` indicating changes in handling `provider` and `scorers`.
  
- In `packages/cli/src/bin/index.ts`, logic is added in the `handleRunCommand` function to automatically assign `provider` and `scorers` to each run if not explicitly set, ensuring default configurations propagate properly across all model runs.

- The `provider` and `scorers` fields have been made optional in the `ModelRunConfig` interface within `packages/types/src/index.ts`, reflecting their optional status in individual run configurations.

- Documentation in all markdown files under `docs/` and examples in `examples/` directories updated to show that `provider` can be set globally for all runs within a configuration file and illustrate that `scorers` can be configured at the root level too.

- Adjustments in JSON configuration examples across multiple directories (`examples/basic`, `examples/chatbot`, `examples/humaneval`, `examples/spider`) demonstrating the removal of duplicated `provider` entries across run configurations, being replaced by a single entry at the root of the configuration file.

- Unit tests updated to check new behavior of configuration parsing including setting `provider` and `scorers` at the root level and their proper propagation into individual runs in `tests/test_packages_cli_src_bin_index.ts.ts` and `tests/test_packages_types_src_index.ts.ts`.

- TODO observed in `packages/cli/src/bin/index.ts` for adding a check to validate runs configuration file, indicating an area that might need further attention post this PR.
}



===== Original PR title and description ============

**Original Title:** Add tests for PR 43

**Original Description:**
## Purpose
This PR adds new tests to the Empirical CLI and types package. The changes include:
- Simplifying the configuration to accept provider and scorers as top-level keys
- Updating the documentation to reflect the new configuration structure
- Adding tests to ensure the configuration is loaded and parsed correctly

## Critical Changes
- The `handleRunCommand` function in `packages/cli/src/bin/index.ts` has been updated to load the provider and scorers from the top-level of the configuration file and apply them to the runs if they are not defined at the individual run level. This ensures consistency in the configuration and makes it easier to manage common settings across multiple runs.
- The default configuration in `packages/cli/src/runs/config/defaults/index.ts` has been updated to include the provider and scorers at the top level, aligning with the new structure.
- New tests have been added in `tests/test_packages_cli_src_bin_index.ts.ts` and `tests/test_packages_cli_src_runs_config_defaults_index.ts.ts` to ensure the configuration is loaded and parsed correctly.



===== Original PR title and description ============

**Original Title:** Add tests pr 43

**Original Description:**
None








